### PR TITLE
fix: read updated shell shim paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ const extractPathFromCmd = cmdshimContents => {
 }
 
 const extractPathFromCygwin = cmdshimContents => {
-  const matches = cmdshimContents.match(/"[$]basedir[/]([^"]+?)"\s+"[$]@"/)
+  const matches = cmdshimContents.match(/"[$]basedir(?:_win)?[/]([^"]+?)"\s+"[$]@"/)
   return matches && matches[1]
 }
 


### PR DESCRIPTION
## Summary

Update the POSIX shell-shim parser to recognize the path form emitted by current versions of `cmd-shim`.

`cmd-shim@9.0.1` added support for invoking Windows executables from WSL. As part of that change, generated shebang-based shell shims began using:

```sh
"$basedir_win/<target>" "$@"
```

instead of:

```sh
"$basedir/<target>" "$@"
```

`read-cmd-shim` currently recognizes only the original `$basedir` form. As a result, it reports newer, valid shell shims as `ENOTASHIM`, even though they were generated by `cmd-shim`.

This change extends the existing parser to accept the optional, literal `_win` suffix. It continues to support older shims and returns the same relative target path for both forms.

## Why

1. `bin-links` installs `cmd-shim` using `^9.0.0`, currently resolving to `9.0.2`.
2. Since `cmd-shim@9.0.1`, shebang-based shell shims use:
`"$basedir_win/<target>" "$@"`
3. `read-cmd-shim@7.0.0` only recognizes:
`"$basedir/<target>" "$@"`
4. During its tests, `bin-links` creates a shim and then verifies/recreates it.
5. `read-cmd-shim` rejects the valid new shim as `ENOTASHIM`.
6. `bin-links` converts that into `EEXIST`, failing the suite and coverage threshold.

## Why this approach

The parser remains intentionally narrow:

- only `$basedir` and `$basedir_win` are recognized
- the existing quoting and `"$@"` structure are still required
- no shell expressions are evaluated
- `.cmd` and PowerShell parsing are unchanged
- asynchronous and synchronous readers continue to share the same extraction logic

This restores compatibility with current `cmd-shim` output without changing the public API or the result returned for existing shims.

## Compatibility

This is backward-compatible:

- shims generated by older `cmd-shim` versions still use `$basedir` and remain supported
- shims generated by `cmd-shim@9.0.1` and newer can now be read through `$basedir_win`
- consumers continue to receive the relative target path
- invalid or unrelated shell files continue to return `ENOTASHIM`

## Testing

- all 18 integration tests pass
- both asynchronous and synchronous shebang shell-shim cases exercise the updated form through the current `cmd-shim` dependency
- 100% line, branch, and function coverage
- ESLint passes
- CI passes across Linux, macOS, and Windows on every configured Node.js version

## Related change

The updated shell-shim form was introduced by npm/cmd-shim#178.
